### PR TITLE
Add testbench for easier testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cachehog
+testbench

--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ Not bad.
 Note: Tested on my machine (i7-4710HQ), probably won't work well or at all on
 others. If you experience issues, try randomly tweaking some parameters.
 
+## Testbench
+
+Compile with `make testbench`.
+
+Run as:
+
+    ./testbench [message]
+
+If you don't specify a message, default one will be used.
+
+Possible output:
+
+    $ ./testbench
+    Message size: 28
+    Estimated running time: 22 sec
+    Received 28 bytes (224 bits)
+    Lost 0 bytes
+    ORG: Lorem ipsum dolor sit amet.
+    REC: Lorm ipsum dolorsit amet.
+    Total error bits: 10, bit error rate: 0.044643
+
+NOTE: testbench does not run any diffing algorithm so if any of byte is lost in
+transmission, error bit count will be higher than you might expect.
+
+NOTE2: unlike `./cachehog` testbench uses POSIX functions so will probably not
+work on Windows (not tested!).
+
 ## Debugging
 
 There are some `printf`s hidden behind the `DEBUG` flag. Look at the source.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ There are several challenges:
     measurement if it's above average, and `1` if it's below average.
 
     TODO: This has significant drawbacks. For example, it's very difficult to
-    recognize the words `00000000` and `11111111`. Maybe use the average from
-    `SYNC` for thresholding the data?
+    recognize the words `00000000` and `11111111`.
 
 ## Running it
 

--- a/cachehog.c
+++ b/cachehog.c
@@ -1,107 +1,5 @@
-#include <time.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include "cachehog_lib.h"
 #include <stdio.h>
-#include <memory.h>
-
-// size of random access buffer
-const int N = 1024 * 1024 * 10;
-
-const int base_interval_ms = 5;
-const int intervals_per_bit = 10;
-
-const int word_size = 8;
-
-const int DEBUG = 0;
-
-int cmp_timespec(struct timespec *a, struct timespec *b) {
-  if(a->tv_sec < b->tv_sec) {
-    return -1;
-  }
-
-  if(a->tv_sec > b->tv_sec) {
-    return 1;
-  }
-
-  if(a->tv_nsec < b->tv_nsec) {
-    return -1;
-  }
-
-  if(a->tv_nsec > b->tv_nsec) {
-    return 1;
-  }
-
-  return 0;
-}
-
-void normalize(struct timespec *val) {
-  while(val->tv_nsec >= 1000000000) {
-    val->tv_sec++;
-    val->tv_nsec -= 1000000000;
-  }
-}
-
-uint32_t *buf;
-
-int measure(int bit_to_transmit) {
-  struct timespec end;
-  clock_gettime(CLOCK_MONOTONIC_RAW, &end);
-  end.tv_nsec += base_interval_ms * 1000000;
-  normalize(&end);
-
-  int count = 0;
-
-  while(1) {
-    struct timespec cur;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &cur);
-    if(cmp_timespec(&end, &cur) <= 0)
-      break;
-
-    if(bit_to_transmit) {
-      for(int j = 0; j < 1000; j++) {
-        buf[rand() % N]++;
-      }
-    }
-    count++;
-  }
-  return count;
-}
-
-void read_bit(int *readings, int nbits) {
-  int val = measure(1);
-  memmove(readings, readings + 1, (nbits - 1) * sizeof(int));
-  readings[nbits-1] = val;
-}
-
-void threshold(int *readings, int *bits, int nbits) {
-  int sum = 0;
-  for(int i = 0; i < nbits; i++) {
-    int v = readings[i];
-    sum += v;
-  }
-  int avg = sum / nbits;
-
-  for(int i = 0; i < nbits; i++) {
-    bits[i] = readings[i] < avg ? 1 : 0;
-  }
-}
-
-int hamming_distance_from_sync(int *bits, int nbits) {
-  int distance = 0;
-  for(int i = 0; i < nbits; i++) {
-    int desired = (i / intervals_per_bit + 1) & 1;
-    if(bits[i] != desired) {
-      distance++;
-    }
-  }
-  return distance;
-}
-
-void transmit(int bit) {
-  for(int j = 0; j < intervals_per_bit; j++) {
-    measure(bit);
-  }
-}
 
 // Transmit mode main loop
 void do_transmit() {
@@ -111,80 +9,23 @@ void do_transmit() {
       break;
     }
 
-    // sync (10101010)
-    for(int i = 0; i < word_size; i++) {
-      transmit((i + 1) & 1);
-    }
-
-    // transmit the word
-    for(int i = 0; i < word_size; i++) {
-      transmit((c & 0x80) ? 1 : 0);
-      c <<= 1;
-    }
+    transmit_word(c);
   }
 }
 
 // Receive mode main loop
 void do_receive() {
-  int nbits = intervals_per_bit * word_size;
-  int readings[nbits];
-  memset(readings, 0, sizeof(readings));
-
   while(1) {
-    read_bit(readings, nbits);
-
-    int bits[nbits];
-    threshold(readings, bits, nbits);
-
-    int distance = hamming_distance_from_sync(bits, nbits);
-
-    if(distance < word_size) {
-      if(DEBUG) {
-        for(int i = 0; i < nbits; i++) {
-          printf("%c", bits[i] + '0');
-        }
-        printf(" %d\n", distance);
-      }
-
-      for(int i = 0; i < nbits; i++) {
-        read_bit(readings, nbits);
-      }
-
-      threshold(readings, bits, nbits);
-
-      int word[word_size];
-      for(int i = 0; i < word_size; i++) {
-        int count = 0;
-        for(int j = 0; j < intervals_per_bit; j++) {
-          count += bits[intervals_per_bit * i + j];
-        }
-        word[i] = count * 2 >= intervals_per_bit ? 1 : 0;
-      }
-
-      if(DEBUG) {
-
-        for(int i = 0; i < word_size; i++) {
-          printf("%c", word[i] + '0');
-        }
-        printf("\n");
-
-      } else {
-        int val = 0;
-        for(int i = 0; i < word_size; i++) {
-          val <<= 1;
-          val |= word[i];
-        }
-        putchar(val);
-        fflush(stdout);
-      }
+    int word = read_word();
+    if(word != 0) {
+      putchar(word);
+      fflush(stdout);
     }
   }
 }
 
 int main(int argc, char **argv) {
-  srand(time(NULL));
-  buf = malloc(N * sizeof(uint32_t));
-  memset(buf, 77,  N * sizeof(uint32_t));
+  init_cachehog();
 
   if(argc >= 2 && !strcmp(argv[1], "transmit")) {
     do_transmit();

--- a/cachehog_lib.h
+++ b/cachehog_lib.h
@@ -1,0 +1,179 @@
+#include <time.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <memory.h>
+#include <stdio.h>
+
+// size of random access buffer
+const int N = 1024 * 1024 * 10;
+
+const int base_interval_ms = 5;
+const int intervals_per_bit = 10;
+
+const int word_size = 8;
+
+const int DEBUG = 0;
+
+uint32_t *buf;
+
+void init_cachehog() {
+  srand(time(NULL));
+  buf = malloc(N * sizeof(uint32_t));
+  memset(buf, 77,  N * sizeof(uint32_t));
+}
+
+int cmp_timespec(struct timespec *a, struct timespec *b) {
+  if(a->tv_sec < b->tv_sec) {
+    return -1;
+  }
+
+  if(a->tv_sec > b->tv_sec) {
+    return 1;
+  }
+
+  if(a->tv_nsec < b->tv_nsec) {
+    return -1;
+  }
+
+  if(a->tv_nsec > b->tv_nsec) {
+    return 1;
+  }
+
+  return 0;
+}
+
+void normalize(struct timespec *val) {
+  while(val->tv_nsec >= 1000000000) {
+    val->tv_sec++;
+    val->tv_nsec -= 1000000000;
+  }
+}
+
+int measure(int bit_to_transmit) {
+  struct timespec end;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+  end.tv_nsec += base_interval_ms * 1000000;
+  normalize(&end);
+
+  int count = 0;
+
+  while(1) {
+    struct timespec cur;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &cur);
+    if(cmp_timespec(&end, &cur) <= 0)
+      break;
+
+    if(bit_to_transmit) {
+      for(int j = 0; j < 1000; j++) {
+        buf[rand() % N]++;
+      }
+    }
+    count++;
+  }
+  return count;
+}
+
+void transmit(int bit) {
+  for(int j = 0; j < intervals_per_bit; j++) {
+    measure(bit);
+  }
+}
+
+void transmit_word(int word) {
+  // sync (10101010)
+  for(int i = 0; i < word_size; i++) {
+    transmit((i + 1) & 1);
+  }
+
+  // transmit the word
+  for(int i = 0; i < word_size; i++) {
+    transmit((word & 0x80) ? 1 : 0);
+    word <<= 1;
+  }
+}
+
+void read_bit(int *readings, int nbits) {
+  int val = measure(1);
+  memmove(readings, readings + 1, (nbits - 1) * sizeof(int));
+  readings[nbits-1] = val;
+}
+
+void threshold(int *readings, int *bits, int nbits) {
+  int sum = 0;
+  for(int i = 0; i < nbits; i++) {
+    int v = readings[i];
+    sum += v;
+  }
+  int avg = sum / nbits;
+
+  for(int i = 0; i < nbits; i++) {
+    bits[i] = readings[i] < avg ? 1 : 0;
+  }
+}
+
+int hamming_distance_from_sync(int *bits, int nbits) {
+  int distance = 0;
+  for(int i = 0; i < nbits; i++) {
+    int desired = (i / intervals_per_bit + 1) & 1;
+    if(bits[i] != desired) {
+      distance++;
+    }
+  }
+  return distance;
+}
+
+int read_word() {
+  int nbits = intervals_per_bit * word_size;
+  int readings[nbits];
+  memset(readings, 0, nbits);
+
+  while(1) {
+    read_bit(readings, nbits);
+
+    int bits[nbits];
+    threshold(readings, bits, nbits);
+
+    int distance = hamming_distance_from_sync(bits, nbits);
+
+    if(distance < word_size) {
+      if(DEBUG) {
+        for(int i = 0; i < nbits; i++) {
+          printf("%c", bits[i] + '0');
+        }
+        printf(" %d\n", distance);
+      }
+
+      for(int i = 0; i < nbits; i++) {
+        read_bit(readings, nbits);
+      }
+
+      threshold(readings, bits, nbits);
+
+      int word[word_size];
+      for(int i = 0; i < word_size; i++) {
+        int count = 0;
+        for(int j = 0; j < intervals_per_bit; j++) {
+          count += bits[intervals_per_bit * i + j];
+        }
+        word[i] = count * 2 >= intervals_per_bit ? 1 : 0;
+      }
+
+      if(DEBUG) {
+
+        for(int i = 0; i < word_size; i++) {
+          printf("%c", word[i] + '0');
+        }
+        printf("\n");
+
+      }
+
+      int val = 0;
+      for(int i = 0; i < word_size; i++) {
+        val <<= 1;
+        val |= word[i];
+      }
+      return val;
+    }
+  }
+}
+

--- a/testbench.c
+++ b/testbench.c
@@ -1,0 +1,102 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sched.h>
+#include <assert.h>
+#include <limits.h>
+#include <signal.h>
+#include "cachehog_lib.h"
+
+uint8_t* message;
+int message_size;
+uint8_t* recv;
+int recc;
+
+void transmitter(const uint8_t* message, size_t size) {
+  init_cachehog();
+
+  for(int i = 0; i < size; i++) {
+    transmit_word(message[i]);
+  }
+}
+
+void after_receiving();
+
+void recv_sighandler(int sig) {
+    after_receiving();
+    _exit(0);
+}
+
+void receiver(const uint8_t* original_message, size_t size) {
+  init_cachehog();
+
+  // Original null-byte is part of transmitted data and could be corrupted
+  // so we have one additional null-byte at the end of the buffer
+  recv = malloc(size+1);
+  recc = 0;
+
+  struct sigaction sigact = { recv_sighandler };
+  sigaction(SIGINT, &sigact, NULL);
+
+  for(int i = 0; i < size; i++) {
+    recv[i] = read_word();
+    recc++;
+  }
+}
+
+int calc_error_count() {
+  int error_count = 0;
+  for(int i = 0; i < message_size; i++) {
+    error_count += __builtin_popcount(message[i] ^ recv[i]);
+  }
+  return error_count;
+}
+
+void after_receiving() {
+  recv[message_size+1] = 0; // additional null-byte at the end for safety
+
+  int error_count = calc_error_count();
+  float ber = error_count / ((float)message_size * word_size);
+
+  printf("Received %d bytes (%d bits)\n", recc, recc * word_size);
+  printf("Lost %d bytes\n", message_size - recc);
+  printf("ORG: %s\n", message);
+  printf("REC: %s\n", recv);
+  printf("Total error bits: %d, bit error rate: %f\n", error_count, ber);
+}
+
+int main(int argc, char** argv) {
+  assert(word_size == sizeof(uint8_t)*8);
+
+  message = (argc > 1) ? argv[1] : "Lorem ipsum dolor sit amet.";
+  message_size = strlen(message)+1;
+
+  int est_running_time_sec =
+    message_size *
+    word_size *
+    2 *   // sync byte
+    intervals_per_bit *
+    base_interval_ms /
+    1000; // ms to s
+
+  printf("Message size: %d\n", message_size);
+  printf("Estimated running time: %d sec\n", est_running_time_sec);
+
+  pid_t pid = fork();
+
+  if(pid == -1) {
+      return EXIT_FAILURE;
+  }
+
+  if(pid != 0) {
+    sched_yield();
+    transmitter(message, message_size);
+    kill(pid, SIGINT);
+  } else {
+    sched_yield();
+    receiver(message, message_size);
+    raise(SIGINT);
+  }
+
+  return 0;
+}

--- a/testbench.c
+++ b/testbench.c
@@ -7,7 +7,7 @@
 #include <signal.h>
 #include "cachehog_lib.h"
 
-uint8_t* message;
+const uint8_t* message;
 int message_size;
 uint8_t* recv;
 int recc;
@@ -52,6 +52,28 @@ int calc_error_count() {
   return error_count;
 }
 
+const char* byte_to_binary(int x) {
+  static char b[9];
+  b[0] = '\0';
+
+  for(int i = 0; i < 8; i++) {
+    b[i] = (x & (128 >> i)) ? '1' : '0';
+  }
+
+  return b;
+}
+void show_error_bytes() {
+  for(int i = 0; i < message_size; i++) {
+    uint8_t diff = message[i] ^ recv[i];
+    if(diff != 0) {
+      printf("\n    %s\n", byte_to_binary(message[i]));
+      printf("    %s\n", byte_to_binary(recv[i]));
+      printf("    --------\n");
+      printf("xor %s  %d\n", byte_to_binary(diff), __builtin_popcount(diff));
+    }
+  }
+}
+
 void after_receiving() {
   recv[message_size+1] = 0; // additional null-byte at the end for safety
 
@@ -62,6 +84,7 @@ void after_receiving() {
   printf("Lost %d bytes\n", message_size - recc);
   printf("ORG: %s\n", message);
   printf("REC: %s\n", recv);
+  show_error_bytes();
   printf("Total error bits: %d, bit error rate: %f\n", error_count, ber);
 }
 


### PR DESCRIPTION
This pull request:
1. Splits cachehog.c into two files: 
  * cachehog_lib.h -- reusable functions for using cachehog transmission
  * cachehog.c -- main program as previously
2. Adds testbench program

Testbench automatically forks itself into transmitter and receiver, tries to send the message and calculates error rates.

This is preparation for work on error correcting codes.